### PR TITLE
Fixed service on centos platform

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,13 +29,21 @@ platforms:
         extra_pip_packages:
           - logutils
           - argparse
+        service:
+          DAEMON: /usr/bin/glances
   - name: centos-6
     attributes:
       glances:
         extra_pip_packages:
           - logutils
           - argparse
+        service:
+          DAEMON: /usr/bin/glances
   - name: centos-7
+    attributes:
+      glances:
+        service:
+          DAEMON: /usr/bin/glances
     driver_config:
       dockerfile: test/dockerfiles/centos7
       privileged: true

--- a/templates/centos/init_script.erb
+++ b/templates/centos/init_script.erb
@@ -1,0 +1,107 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          glances
+# Required-Start:    $remote_fs $local_fs $network
+# Required-Stop:     $remote_fs $local_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts and daemonize Glances server
+# Description:       Starts and daemonize Glances server
+### END INIT INFO
+
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Glances server"
+NAME=glances
+USER=$NAME
+DAEMON="/usr/bin/$NAME"
+PIDFILE="/run/$NAME/$NAME.pid"
+CONF="/etc/glances/glances.conf"
+DAEMON_ARGS="-C $CONF -s"
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+# Ensure /run/glances is there, cf. Debian policy 9.4.1
+# http://www.debian.org/doc/debian-policy/ch-opersys.html#s-fhs-run
+if [ ! -d "$(dirname $PIDFILE)" ]; then
+    mkdir -p "$(dirname $PIDFILE)"
+    chown $USER:$USER "$(dirname $PIDFILE)"
+    chmod 755 "$(dirname $PIDFILE)"
+fi
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+    echo "Starting $DESC"
+    [ -e $PIDFILE ] && PID=$(cat "$PIDFILE")
+    if ( [ -e $PIDFILE ] && ps -p $PID 1>&2 > /dev/null )
+    then
+        failure "already running, PID's $PID"
+        exit 1
+    elif ( [ -w $PIDFILE ] )
+    then
+        warning "PID file found while ${NAME} is not running, removing file."
+        rm $PIDFILE
+    fi
+
+    if [ "$RUN" != "true" ]; then
+        passed "Not starting glances: disabled by /etc/default/$NAME".
+        exit 2
+    fi
+
+    su - $USER -c "setsid $DAEMON $DAEMON_ARGS &>/dev/null & jobs -p %1 > $PIDFILE"
+    [ -e "$PIDFILE" ] && chown $USER $PIDFILE
+    success "$NAME started"
+    exit 0
+}
+
+do_stop()
+{
+    echo "Stopping $DESC"
+    if [ ! -w $PIDFILE ]
+    then
+        warning "PID file not found"
+        exit 1
+    fi
+    killproc -p $PIDFILE bash
+    /bin/rm -f $PIDFILE
+    exit 0
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+  stop)
+    do_stop
+    ;;
+  status)
+    status -p "$PIDFILE" "$DAEMON"
+    ;;
+  restart|force-reload)
+    do_stop
+    case "$?" in
+      0)
+        success
+        do_start
+        ;;
+      *)
+        failure
+        ;;
+    esac
+    ;;
+  *)
+    echo "Usage: invoke-rc.d $NAME {start|stop|status|restart|force-reload}" >&2
+    exit 3
+    ;;
+esac


### PR DESCRIPTION
Add specific init script template for centos platform. This script was
simplified for readability, debian service will follow.

Also fixed kitchen centos instances to use proper glances bin
script (/usr/bin/glances instead of /usr/local/bin/glances)